### PR TITLE
Fix logging 

### DIFF
--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -34,12 +34,12 @@ func (c *Controller) acceptNetworkPolicy(p packet) bool {
 	srcPodNetworkPolices := c.getNetworkPoliciesForPod(srcPod)
 	dstPodNetworkPolices := c.getNetworkPoliciesForPod(dstPod)
 
-	msg := fmt.Sprintf("checking packet %s:", p.String())
+	msg := fmt.Sprintf("checking packet %s", p.String())
 	if srcPod != nil {
-		msg += fmt.Sprintf(" SrcPod (%s/%s): %d NetworkPolicy", srcPod.Name, srcPod.Namespace, len(srcPodNetworkPolices))
+		msg += fmt.Sprintf("\nSrcPod (%s/%s): %d NetworkPolicy", srcPod.Name, srcPod.Namespace, len(srcPodNetworkPolices))
 	}
 	if dstPod != nil {
-		msg += fmt.Sprintf(" DstPod (%s/%s): %d NetworkPolicy", dstPod.Name, dstPod.Namespace, len(dstPodNetworkPolices))
+		msg += fmt.Sprintf("\nDstPod (%s/%s): %d NetworkPolicy", dstPod.Name, dstPod.Namespace, len(dstPodNetworkPolices))
 	}
 	klog.V(2).Infof("%s", msg)
 

--- a/pkg/networkpolicy/packet.go
+++ b/pkg/networkpolicy/packet.go
@@ -20,7 +20,7 @@ type packet struct {
 }
 
 func (p packet) String() string {
-	return fmt.Sprintf("%s:%d %s:%d %s :: %s", p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
+	return fmt.Sprintf("%s:%d %s:%d %s\n%s", p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
 }
 
 // https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Packet_structure


### PR DESCRIPTION
Current formatting is broken , the hexdump is multiline, is useful because it shows the ascii characters :)

https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-network-policies/1782092897366052864/artifacts/bootstrap-e2e-minion-group-20kx/kube-network-policies.log

```
: DstPod (coredns-58cd89f5d-wqdbl/kube-system): 0 NetworkPolicy
I0421 17:13:49.049750       7 controller.go:327] Finished syncing packet 21 took: 72.78µs accepted: true
I0421 17:13:49.156862       7 controller.go:308] Processing sync for packet 22
I0421 17:13:49.156947       7 controller.go:463] checking packet 10.64.2.5:40523 10.64.1.3:53 TCP :: 00000000  00 00 a0 02 7f 94 31 8c  00 00 02 04 05 8c 04 02  |......1.........|
00000010  08 0a 0f 2c c0 89 00 00  00 00 01 03 03 07        |...,..........|
: DstPod (coredns-58cd89f5d-wqdbl/kube-system): 0 NetworkPolicy
```