### PR TITLE
Cross-compile for arm64 and mount go cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,15 @@ REGISTRY?=gcr.io/k8s-staging-networking
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 # the full image tag
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
+PLATFORMS?=linux/amd64,linux/arm64
 
-# required to enable buildx
-export DOCKER_CLI_EXPERIMENTAL=enabled
 image-build:
-# docker buildx build --platform=${PLATFORMS} $(OUTPUT) --progress=$(PROGRESS) -t ${IMAGE} --pull $(EXTRA_BUILD_OPT) .
-	docker build . -t ${IMAGE}
+	docker buildx build . \
+		--tag="${IMAGE}" \
+		--load
+
+image-push:
+	docker buildx build . \
+		--platform="${PLATFORMS}" \
+		--tag="${IMAGE}" \
+		--push


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/kube-network-policies/issues/29

Provides is a very efficient way to build multi-arch images: https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

Adds `image-push` which pushes the multi-arch images to the configured registry under one manifest that works. This should be used in place of `make image-build` + `docker push`.