### PR TITLE
Only process traffic impacted by network policies

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,11 +64,17 @@ func main() {
 		klog.Fatalf("error parsing metrics bind address %s : %v", metricsBindAddress, err)
 	}
 
+	nodeName := os.Getenv("MY_NODE_NAME")
+	if nodeName == "" {
+		klog.Fatalf("node name not set, please set the environment variable using the Downward API")
+	}
+
 	cfg := networkpolicy.Config{
 		AdminNetworkPolicy:         adminNetworkPolicy,
 		BaselineAdminNetworkPolicy: baselineAdminNetworkPolicy,
 		FailOpen:                   failOpen,
 		QueueID:                    queueID,
+		NodeName:                   nodeName,
 	}
 	// creates the in-cluster config
 	config, err := rest.InClusterConfig()

--- a/install-anp.yaml
+++ b/install-anp.yaml
@@ -93,6 +93,11 @@ spec:
           privileged: true
           capabilities:
             add: ["NET_ADMIN"]
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       volumes:
       - name: lib-modules
         hostPath:

--- a/install.yaml
+++ b/install.yaml
@@ -86,6 +86,11 @@ spec:
           privileged: true
           capabilities:
             add: ["NET_ADMIN"]
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       volumes:
       - name: lib-modules
         hostPath:


### PR DESCRIPTION
optimize the datapath not having to send all packets to user space, only the ones that are subject of network policies


Fixes: https://github.com/kubernetes-sigs/kube-network-policies/issues/10, #31, #12

