### PR TITLE
Use structured logging

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,9 @@ import (
 	v1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/component-base/logs"
+	logsapi "k8s.io/component-base/logs/api/v1"
+	_ "k8s.io/component-base/logs/json/register"
 	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/klog/v2"
 
@@ -52,17 +55,37 @@ func init() {
 	}
 }
 
+// This is a pattern to ensure that deferred functions executes before os.Exit
 func main() {
-	// enable logging
-	klog.InitFlags(nil)
+	os.Exit(run())
+}
+func run() int {
+	// Enable logging in the Kubernetes core package way (support json output)
+	// https://github.com/kubernetes/component-base/tree/master
+	c := logsapi.NewLoggingConfiguration()
+	logsapi.AddGoFlags(c, flag.CommandLine)
 	flag.Parse()
+	logs.InitLogs()
+	if err := logsapi.ValidateAndApply(c, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return 1
+	}
+
+	// Create a context for structured logging, and catch termination signals
+	ctx, cancel := signal.NotifyContext(
+		context.Background(), os.Interrupt, unix.SIGINT)
+	defer cancel()
+
+	logger := klog.FromContext(ctx)
+	logger.Info("called", "args", flag.Args())
 
 	flag.VisitAll(func(flag *flag.Flag) {
-		klog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+		logger.Info("flag", "name", flag.Name, "value", flag.Value)
 	})
 
 	if _, _, err := net.SplitHostPort(metricsBindAddress); err != nil {
-		klog.Fatalf("error parsing metrics bind address %s : %v", metricsBindAddress, err)
+		logger.Error(err, "parsing metrics bind address", "address", metricsBindAddress)
+		return 1
 	}
 
 	nodeName, err := nodeutil.GetHostname(hostnameOverride)
@@ -95,18 +118,6 @@ func main() {
 	if err != nil {
 		panic(err.Error())
 	}
-
-	// trap Ctrl+C and call cancel on the context
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-
-	// Enable signal handler
-	signalCh := make(chan os.Signal, 2)
-	defer func() {
-		close(signalCh)
-		cancel()
-	}()
-	signal.Notify(signalCh, os.Interrupt, unix.SIGINT)
 
 	informersFactory := informers.NewSharedInformerFactory(clientset, 0)
 
@@ -149,7 +160,8 @@ func main() {
 		cfg,
 	)
 	if err != nil {
-		klog.Fatalf("Can not start network policy controller: %v", err)
+		logger.Error(err, "Can not start network policy controller")
+		return 1
 	}
 	go func() {
 		err := networkPolicyController.Run(ctx)
@@ -161,13 +173,9 @@ func main() {
 		npaInformerFactory.Start(ctx.Done())
 	}
 
-	select {
-	case <-signalCh:
-		klog.Infof("Exiting: received signal")
-		cancel()
-	case <-ctx.Done():
-	}
+	<-ctx.Done()
 
 	// grace period to cleanup resources
 	time.Sleep(5 * time.Second)
+	return 0
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.12.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -53,6 +54,8 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -1,6 +1,7 @@
 package networkpolicy
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -439,7 +440,7 @@ func TestSyncPacket(t *testing.T) {
 				}
 			}
 
-			ok := controller.evaluatePacket(tt.p)
+			ok := controller.evaluatePacket(context.TODO(), tt.p)
 			if ok != tt.expect {
 				t.Errorf("expected %v got  %v", ok, tt.expect)
 			}
@@ -484,7 +485,7 @@ func TestController_evaluateSelectors(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			if got := c.evaluateSelectors(tt.peerPodSelector, tt.peerNSSelector, tt.pod, tt.policyNs); got != tt.want {
+			if got := c.evaluateSelectors(context.TODO(), tt.peerPodSelector, tt.peerNSSelector, tt.pod, tt.policyNs); got != tt.want {
 				t.Errorf("Controller.evaluateSelectors() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/networkpolicy/networkpolicyapi_test.go
+++ b/pkg/networkpolicy/networkpolicyapi_test.go
@@ -1,6 +1,7 @@
 package networkpolicy
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -480,7 +481,7 @@ func Test_adminNetworkPolicyAction(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ok := controller.evaluatePacket(tt.p)
+			ok := controller.evaluatePacket(context.TODO(), tt.p)
 			if ok != tt.expect {
 				t.Errorf("expected %v got  %v", tt.expect, ok)
 			}
@@ -731,7 +732,7 @@ func TestController_getAdminNetworkPoliciesForPod(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if got := controller.getAdminNetworkPoliciesForPod(makePod("a", "foo", "192.168.1.11")); len(got) > 0 != tt.want {
+			if got := controller.getAdminNetworkPoliciesForPod(context.TODO(), makePod("a", "foo", "192.168.1.11")); len(got) > 0 != tt.want {
 				t.Errorf("Controller.getAdminNetworkPoliciesForPod() = %v, want %v", len(got) > 0, tt.want)
 			}
 		})

--- a/pkg/networkpolicy/packet.go
+++ b/pkg/networkpolicy/packet.go
@@ -28,6 +28,27 @@ func (p packet) String() string {
 	return fmt.Sprintf("[%d] %s:%d %s:%d %s\n%s", p.id, p.srcIP.String(), p.srcPort, p.dstIP.String(), p.dstPort, p.proto, hex.Dump(p.payload))
 }
 
+// This function is used for JSON output (interface logr.Marshaler)
+func (p packet) MarshalLog() any {
+	return &struct {
+		ID      uint32
+		Family  v1.IPFamily
+		SrcIP   net.IP
+		DstIP   net.IP
+		Proto   v1.Protocol
+		SrcPort int
+		DstPort int
+	}{
+		p.id,
+		p.family,
+		p.srcIP,
+		p.dstIP,
+		p.proto,
+		p.srcPort,
+		p.dstPort,
+	}
+}
+
 // https://en.wikipedia.org/wiki/Internet_Protocol_version_4#Packet_structure
 // https://en.wikipedia.org/wiki/IPv6_packet
 // https://github.com/golang/net/blob/master/ipv4/header.go


### PR DESCRIPTION
Use structured logging in json format if `-logging-format=json` is specified. The same setup functions as for K8s core packages are used ([component-base](https://github.com/kubernetes/component-base/tree/master)).

Also, [contextual logging](https://kubernetes.io/blog/2023/12/20/contextual-logging-in-kubernetes-1-29/) is used (beta in 1.30, so no feature-gateway is needed). 

Fixes #48 

This PR will be a draft until all code is changed to use structured/contextual logging.