### PR TITLE
Process packets only on the POSTROUTING hook (before SNAT)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,9 +55,11 @@ jobs:
       matrix:
         # TODO add "dual", waiting on KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3705-cloud-node-ips
         ipFamily: ["ipv4", "ipv6"]
+        proxyMode: ["iptables", "ipvs"]
     env:
-      JOB_NAME: "kube-network-policies-${{ matrix.ipFamily }}"
+      JOB_NAME: "kube-network-policies-${{ matrix.ipFamily }}-${{ matrix.proxyMode }}"
       IP_FAMILY: ${{ matrix.ipFamily }}
+      KUBEPROXY_MODE: ${{ matrix.proxyMode }}
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -99,6 +101,7 @@ jobs:
         apiVersion: kind.x-k8s.io/v1alpha4
         networking:
           ipFamily: ${IP_FAMILY}
+          kubeProxyMode: ${KUBEPROXY_MODE}
         nodes:
         - role: control-plane
         - role: worker

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,8 @@ on:
 
 env:
   GO_VERSION: "1.22.0"
-  K8S_VERSION: "v1.29.2"
-  KIND_VERSION: "v0.22.0"
+  K8S_VERSION: "v1.30.0"
+  KIND_VERSION: "v0.23.0"
   IMAGE_NAME: registry.k8s.io/networking/kube-network-policies
   KIND_CLUSTER_NAME: kind
 
@@ -55,6 +55,7 @@ jobs:
       matrix:
         # TODO add "dual", waiting on KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3705-cloud-node-ips
         ipFamily: ["ipv4", "ipv6"]
+        # TODO add nftables (beta in 1.31) waiting for 1.31 images
         proxyMode: ["iptables", "ipvs"]
     env:
       JOB_NAME: "kube-network-policies-${{ matrix.ipFamily }}-${{ matrix.proxyMode }}"

--- a/.github/workflows/npa.yml
+++ b/.github/workflows/npa.yml
@@ -13,8 +13,8 @@ on:
 
 env:
   GO_VERSION: "1.22.0"
-  K8S_VERSION: "v1.29.2"
-  KIND_VERSION: "v0.22.0"
+  K8S_VERSION: "v1.30.0"
+  KIND_VERSION: "v0.23.0"
   IMAGE_NAME: registry.k8s.io/networking/kube-network-policies
   KIND_CLUSTER_NAME: kind
 

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -689,6 +689,12 @@ func (c *Controller) syncNFTablesRules(ctx context.Context) error {
 		tx.Flush(&knftables.Chain{
 			Name: chainName,
 		})
+		// IPv6 needs ICMP Neighbor Discovery to work
+		tx.Add(&knftables.Rule{
+			Chain: chainName,
+			Rule: knftables.Concat(
+				"icmpv6", "type", "{", "nd-neighbor-solicit, nd-neighbor-advert", "}", "accept"),
+		})
 		// instead of aggregating all the expresion in one rule, use two different
 		// rules to understand if is causing issues with UDP packets with the same
 		// tuple (https://github.com/kubernetes-sigs/kube-network-policies/issues/12)

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -684,7 +684,7 @@ func (c *Controller) syncNFTablesRules(ctx context.Context) error {
 			Name:     chainName,
 			Type:     knftables.PtrTo(knftables.FilterType),
 			Hook:     knftables.PtrTo(hook),
-			Priority: knftables.PtrTo(knftables.FilterPriority + "-5"),
+			Priority: knftables.PtrTo(knftables.SNATPriority + "-5"),
 		})
 		tx.Flush(&knftables.Chain{
 			Name: chainName,

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -674,8 +674,11 @@ func (c *Controller) syncNFTablesRules(ctx context.Context) error {
 			})
 		}
 	}
-
-	for _, hook := range []knftables.BaseChainHook{knftables.ForwardHook} {
+	// Process the packets that are, usually on the FORWARD hook, but
+	// IPVS packets follow a different path in netfilter, so we process
+	// everything in the POSTROUTING hook before SNAT happens.
+	// Ref: https://github.com/kubernetes-sigs/kube-network-policies/issues/46
+	for _, hook := range []knftables.BaseChainHook{knftables.PostroutingHook} {
 		chainName := string(hook)
 		tx.Add(&knftables.Chain{
 			Name:     chainName,

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -540,13 +540,13 @@ func (c *Controller) evaluatePacket(p packet) bool {
 	dstPodNetworkPolices := c.getNetworkPoliciesForPod(dstPod)
 	if len(dstPodNetworkPolices) > 0 {
 		allowed := c.evaluator(dstPodNetworkPolices, networkingv1.PolicyTypeIngress, dstPod, dstPort, srcPod, srcIP, srcPort, protocol)
-		klog.V(2).Infof("[Packet %d] Egress NetworkPolicies: %d Allowed: %v", p.id, len(dstPodNetworkPolices), allowed)
+		klog.V(2).Infof("[Packet %d] Ingress NetworkPolicies: %d Allowed: %v", p.id, len(dstPodNetworkPolices), allowed)
 		return allowed
 	}
 	if c.config.BaselineAdminNetworkPolicy {
 		dstPodBaselineAdminNetworkPolices := c.getBaselineAdminNetworkPoliciesForPod(dstPod)
 		action := c.evaluateBaselineAdminIngress(dstPodBaselineAdminNetworkPolices, srcPod, dstPort, protocol)
-		klog.V(2).Infof("[Packet %d] Egress BaselineAdminNetworkPolicies: %d Action: %s", p.id, len(dstPodBaselineAdminNetworkPolices), action)
+		klog.V(2).Infof("[Packet %d] Ingress BaselineAdminNetworkPolicies: %d Action: %s", p.id, len(dstPodBaselineAdminNetworkPolices), action)
 		switch action {
 		case npav1alpha1.BaselineAdminNetworkPolicyRuleActionDeny: // Deny the packet no need to check anything else
 			return false


### PR DESCRIPTION
We only need to process packets that are destined to Pods, never destined to the local host.
Based on the netfilter diagram https://wiki.nftables.org/wiki-nftables/index.php/Netfilter_hooks this can be on FORWARD and POSTROUTING.
However, FORWARD does not work with IPVS, as it seems the IPVS kernel logic follows a different path http://www.austintek.com/LVS/LVS-HOWTO/HOWTO/LVS-HOWTO.filter_rules.html
Using OUTPUT forces us to discriminate the traffic that is destined to localhost to avoid being impacted by network policies, usually adding a rule to accept packets to `lo`.
Using POSTROUTING before SNAT happens (to avoid to loose the original source IP) seems the right place

Fixes: https://github.com/kubernetes-sigs/kube-network-policies/issues/46