### PR TITLE
chore: using self docker builder for multi-platform images.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 PLATFORMS?=linux/amd64,linux/arm64
 
+.PHONY: ensure-buildx
+ensure-buildx:
+	./hack/init-buildx.sh
+	
 image-build:
 	docker buildx build . \
 		--tag="${IMAGE}" \
@@ -47,3 +51,6 @@ image-push:
 		--platform="${PLATFORMS}" \
 		--tag="${IMAGE}" \
 		--push
+
+.PHONY: release # Build a multi-arch docker image
+release: ensure-buildx image-push

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,6 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
   entrypoint: make
-  args: ['image-push']
+  args: ['release']

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# We can skip setup if the current builder already has multi-arch
+# AND if it isn't the docker driver, which doesn't work
+current_builder="$(docker buildx inspect)"
+# linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7, linux/arm/v6
+if ! grep -q "^Driver: docker$" <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}"; then
+  exit 0
+fi
+
+# Ensure qemu is in binfmt_misc
+# Docker desktop already has these in versions recent enough to have buildx
+# We only need to do this setup on linux hosts
+if [ "$(uname)" == 'Linux' ]; then
+  # NOTE: this is pinned to a digest for a reason!
+  docker run --rm --privileged tonistiigi/binfmt:qemu-v7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55 --install all
+fi
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx rm knp-builder || true
+docker buildx create --use --name=knp-builder


### PR DESCRIPTION

releated https://github.com/kubernetes-sigs/kube-network-policies/issues/70

```
error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```

following the error log to switch other builder for build image.

I have check other project for multi-platform images and basically, a specific builder will be created.

- https://github.com/kubernetes/ingress-nginx/blob/main/hack/init-buildx.sh
- https://github.com/kubernetes-sigs/kwok/blob/da3756aca50a589d084592ee0ded8ffd425e566e/cloudbuild.yaml#L24

and the file `hack/init-buildx.sh` is copy from https://github.com/kubernetes-sigs/kind/blob/main/hack/build/init-buildx.sh
