### PR TITLE
chore: change env IMAGE to KNP_IMAGE for build image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ REGISTRY?=gcr.io/k8s-staging-networking
 # tag based on date-sha
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
 # the full image tag
-IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
+KNP_IMAGE?=$(REGISTRY)/$(IMAGE_NAME):$(TAG)
 PLATFORMS?=linux/amd64,linux/arm64
 
 .PHONY: ensure-buildx
@@ -43,13 +43,13 @@ ensure-buildx:
 	
 image-build:
 	docker buildx build . \
-		--tag="${IMAGE}" \
+		--tag="${KNP_IMAGE}" \
 		--load
 
 image-push:
 	docker buildx build . \
 		--platform="${PLATFORMS}" \
-		--tag="${IMAGE}" \
+		--tag="${KNP_IMAGE}" \
 		--push
 
 .PHONY: release # Build a multi-arch docker image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,4 +5,7 @@ options:
 steps:
 - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
   entrypoint: make
+  env:
+  - REGISTRY=gcr.io/k8s-staging-networking
+  - IMAGE_NAME=kube-network-policies
   args: ['release']


### PR DESCRIPTION
releated https://github.com/kubernetes-sigs/kube-network-policies/issues/70

```
#19 ERROR: failed to push gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://gcr.io/v2/token?scope=repository%3Ak8s-staging-test-infra%2Fgcb-docker-gcloud%3Apull%2Cpush&service=gcr.io: 403 Forbidden

```

stil failing post the build image, the reason is  there is an IMG `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36`  environment variable by default. This causes `kube-network-policies` to be pushed to the wrong image repository when building the image.

```shell
kube-network-policies$ docker inspect gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36|grep IMAGE
                "IMAGE=gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36",
```

  see https://github.com/kubernetes/test-infra/blob/c3c3ae29e0eca28eb4349a99d5605beb0103f1b7/images/gcb-docker-gcloud/Dockerfile#L24
  
  
  so this PR is working for change the environment IMAGE to `KNP_IMAGE`, i think it can resolve it. But if there is any way to use prowjob to test ahead of time based on this PR, that would be great