### PR TITLE
performance: optimize memory usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/kube-network-policies
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/florianl/go-nfqueue v1.3.2


### PR DESCRIPTION
In a ~15k Pod cluster, I see this drop memory footprint from about 200MB to 66MB.

This has a few improvements:
* Don't just strip managed fields, but keep only exactly what we want.
* Intern strips to reduce duplication of common things (label keys are almost always duplicated, etc)
* During startup only, GC more aggressively. The problem with the above approach is we get the full object *then* drop it. So if we don't manually GC, we will bloat up and not recover for a long time.

Some of this is overkill I think, I will see what I can remove and see what benefits remain so we don't have too much complexity where we don't get benefits.

Before/after: see the green vs purple line, ignore the rest...

![2024-10-03_14-49-51](https://github.com/user-attachments/assets/d950b6db-51a5-47a0-b1ea-b4926d50b55a)

