### PR TITLE
Workaround dns kernel bug

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,9 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
-	klog.Infof("flags: %v", flag.Args())
+	flag.VisitAll(func(flag *flag.Flag) {
+		klog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+	})
 
 	if _, _, err := net.SplitHostPort(metricsBindAddress); err != nil {
 		klog.Fatalf("error parsing metrics bind address %s : %v", metricsBindAddress, err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ var (
 	queueID                    int
 	metricsBindAddress         string
 	hostnameOverride           string
+	netfilterBug1766Fix        bool
 )
 
 func init() {
@@ -43,6 +44,7 @@ func init() {
 	flag.IntVar(&queueID, "nfqueue-id", 100, "Number of the nfqueue used")
 	flag.StringVar(&metricsBindAddress, "metrics-bind-address", ":9080", "The IP address and port for the metrics server to serve on")
 	flag.StringVar(&hostnameOverride, "hostname-override", "", "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
+	flag.BoolVar(&netfilterBug1766Fix, "netfilter-bug-1766-fix", true, "If set, process DNS packets on the PREROUTING hooks to avoid the race condition on the conntrack subsystem, not needed for kernels 6.12+ (see https://bugzilla.netfilter.org/show_bug.cgi?id=1766)")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: kube-network-policies [options]\n\n")
@@ -74,6 +76,7 @@ func main() {
 		FailOpen:                   failOpen,
 		QueueID:                    queueID,
 		NodeName:                   nodeName,
+		NetfilterBug1766Fix:        netfilterBug1766Fix,
 	}
 	// creates the in-cluster config
 	config, err := rest.InClusterConfig()

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -123,7 +123,7 @@ func newController(client clientset.Interface,
 		nft:    nft,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "controllerName"},
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName},
 		),
 	}
 


### PR DESCRIPTION
Add a workaround to the netfilter conntrack bug https://bugzilla.netfilter.org/show_bug.cgi?id=1766 fixed by https://github.com/torvalds/linux/commit/8af79d3edb5fd2dce35ea0a71595b6d4f9962350.

Since the race problem is caused by having two packets DNATed with the same tuple at the same time by different CPUs, it impact specially DNS resolvers that sends A and AAAA request in parallel (it seems is default glibc behavior), and this is very visible to users that notice DNS latency.

Instead of processing all packets on the POSROUTING hook, special case DNS and process them in PREROUTING after DNAT happens.

Services implementations that don't rely on conntrack can disable this behavior by setting the flag to false.