### PR TITLE
Add helm chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@ Implementation of Kubernetes Network Policies:
 
 ## Install
 
+### Manual Installation
+
 There are two manifest in the current repository:
 
 1. For "traditional" Kubernetes Network policies just do:
 
-```
+```sh
 kubectl apply -f install.yaml
 ```
 
 2. For the Admin Network Policies and Baseline Admin Network Policies the CRDs has to be installed first:
-```
+
+```sh
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.1.5/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
@@ -23,9 +26,24 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-polic
 
 and then install the daemonset enabling the features with the corresponding flags:
 
-```
+```sh
 kubectl apply -f install-anp.yaml
 ```
+
+### Helm
+
+To install kube-network-policies via Helm run:
+
+```sh
+helm install kube-network-policies -n kube-system charts/kube-network-policies
+```
+
+Admin Network Policies and Baseline Admin Network Policies features are controlled by `Values.adminNetworkPolicy` and
+they are enabled by default. Disable them if needed in values.yaml or use `--set adminNetworkPolicy=false` when running
+`helm install` command. 
+
+NOTE: the corresponding CRDs must be installed first.
+
 
 ## Metrics
 

--- a/charts/kube-network-policies/.helmignore
+++ b/charts/kube-network-policies/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kube-network-policies/Chart.yaml
+++ b/charts/kube-network-policies/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kube-network-policies
+description: A Helm chart for Kubernetes Network Policies
+type: application
+version: 0.0.1
+appVersion: "0.0.1"

--- a/charts/kube-network-policies/templates/_helpers.tpl
+++ b/charts/kube-network-policies/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-network-policies.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-network-policies.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-network-policies.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-network-policies.labels" -}}
+helm.sh/chart: {{ include "kube-network-policies.chart" . }}
+{{ include "kube-network-policies.selectorLabels" . }}
+k8s-app: {{ include "kube-network-policies.name" . }}
+tier: node
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kube-network-policies.selectorLabels" -}}
+app: {{ include "kube-network-policies.name" . }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-network-policies.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kube-network-policies.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kube-network-policies/templates/daemonset.yaml
+++ b/charts/kube-network-policies/templates/daemonset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "kube-network-policies.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-network-policies.labels" . | nindent 4 }}
+    {{- with .Values.daemonset.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.daemonset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kube-network-policies.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kube-network-policies.labels" . | nindent 8 }}
+        {{- with .Values.daemonset.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirst
+      {{- with .Values.daemonset.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.daemonset.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kube-network-policies.serviceAccountName" . }}
+      containers:
+        - name: kube-network-policies
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          args:
+            - /bin/netpol
+            - --hostname-override=$(MY_NODE_NAME)
+            - --v=2
+            {{- if .Values.baselineAdminNetworkPolicy }}
+            - --nfqueue-id=99
+            - --admin-network-policy=true
+            - --baseline-admin-network-policy=true
+            {{- else }}
+            - --nfqueue-id=98
+            {{- end }}
+          {{- with .Values.daemonset.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.daemonset.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- with .Values.daemonset.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: lib-modules
+              mountPath: /lib/modules
+              readOnly: true
+      volumes:
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules

--- a/charts/kube-network-policies/templates/daemonset.yaml
+++ b/charts/kube-network-policies/templates/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
             - /bin/netpol
             - --hostname-override=$(MY_NODE_NAME)
             - --v=2
-            {{- if .Values.baselineAdminNetworkPolicy }}
+            {{- if .Values.adminNetworkPolicy }}
             - --nfqueue-id=99
             - --admin-network-policy=true
             - --baseline-admin-network-policy=true

--- a/charts/kube-network-policies/templates/serviceaccount.yaml
+++ b/charts/kube-network-policies/templates/serviceaccount.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-network-policies.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kube-network-policies.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kube-network-policies.serviceAccountName" . }}
+  labels:
+    {{- include "kube-network-policies.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+      {{- if .Values.baselineAdminNetworkPolicy }}
+      - nodes
+      {{- end }}
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - watch
+  {{- if .Values.baselineAdminNetworkPolicy }}
+  - apiGroups:
+      - "policy.networking.k8s.io"
+    resources:
+      - adminnetworkpolicies
+      - baselineadminnetworkpolicies
+    verbs:
+      - list
+      - watch
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kube-network-policies.serviceAccountName" . }}
+  labels:
+    {{- include "kube-network-policies.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kube-network-policies.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kube-network-policies.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/kube-network-policies/values.yaml
+++ b/charts/kube-network-policies/values.yaml
@@ -1,0 +1,31 @@
+image:
+  repository: registry.k8s.io/networking/kube-network-policies
+  pullPolicy: IfNotPresent
+  tag: "v0.6.0"
+
+nameOverride: ""
+fullnameOverride: ""
+
+baselineAdminNetworkPolicy: true
+
+serviceAccount:
+  annotations: {}
+  name: kube-network-policies
+
+daemonset:
+  annotations: {}
+  labels: {}
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - operator: Exists
+      effect: NoSchedule
+  extraEnv: []
+  securityContext:
+    privileged: true
+    capabilities:
+      add: ["NET_ADMIN"]
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "50Mi"

--- a/charts/kube-network-policies/values.yaml
+++ b/charts/kube-network-policies/values.yaml
@@ -6,7 +6,7 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-baselineAdminNetworkPolicy: true
+adminNetworkPolicy: true
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
Addresses #98 

To test run `helm install kube-network-policies -n kube-system charts/kube-network-policies`.
`admin-network-policy` and `baseline-admin-network-policy` are [enabled by default](https://github.com/kubernetes-sigs/kube-network-policies/compare/main...mneverov:kube-network-policies:helm?expand=1#diff-80cda0676b5576ede7ef733618470247b0b084a60de2300c0ec3b7e6fd1b63bbR9) (values file `baselineAdminNetworkPolicy: true`).
