### PR TITLE
[Docs] comment on udp and effected pods in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ Network policies are hard to implement efficiently and in large clusters this is
 
 Most of the existing implementations use the same approach of processing the APIs and transforming them in the corresponding dataplane implementation: iptables, nftables, ebpf or ovs, ...
 
-This project takes a different approach. It uses the NFQUEUE functionality implemented in netfilter to process the first packet of each connection in userspace and emit a verdict. The advantage is that the dataplane implementation does not need to represent all the complex logic, allowing it to scale better. The disadvantage is that we need to pass each new connection packet through userspace.
+This project takes a different approach. It uses the NFQUEUE functionality implemented in netfilter to process the first packet of each connection (or udp flows) in userspace and emit a verdict. The advantage is that the dataplane implementation does not need to represent all the complex logic, allowing it to scale better. The disadvantage is that we need to pass each new connection packet through userspace. Subsequent packets are accepted via a  "ct state established,related accept" rule.
 
-There are some performance improvements that can be applied, such as to restrict in the dataplane the packets that are sent to userspace to the ones that have network policies only, so only
-the Pods affected by network policies will hit the first byte performance.
+For performance only the Pods selected by network policies will be queued to user space and thus absorb the first packet perf hit. 
 
 ## Testing
 


### PR DESCRIPTION
Wasn't clear that udp didn't get send every packet to user space so after I confirmed that established also ignored tcp flows I thought I'd update the readme. 

Also the readme made it seem like ignoring non selected pods was a future optimization but it seems already one so I updated that paragraph too. 

Somewhat related to #99 