### PR TITLE
Liveness probes

### DIFF
--- a/pkg/networkpolicy/dnsagent.go
+++ b/pkg/networkpolicy/dnsagent.go
@@ -290,8 +290,10 @@ func (n *DomainCache) handleDNSPacket(ctx context.Context, pkt packet) {
 		}
 
 		// take the minimum ttl value
-		if h.TTL > 0 && int(h.TTL) < ttl {
+		if ttl == 0 {
 			ttl = int(h.TTL)
+		} else {
+			ttl = min(ttl, int(h.TTL))
 		}
 	}
 	if len(ips) > 0 {

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -3,6 +3,7 @@
 set -eu
 
 function setup_suite {
+  export BATS_TEST_TIMEOUT=120
   # Define the name of the kind cluster
   export CLUSTER_NAME="netpol-test-cluster"
   export IMAGE_NAME="registry.k8s.io/networking/kube-network-policies"


### PR DESCRIPTION
Regression test to ensure kubelet probes don't get blocked
cc: @LiorLieberman 
Fixes: https://github.com/kubernetes-sigs/kube-network-policies/issues/150