### PR TITLE
Optimize performance with IP+Port Filtering and nftable update

### DIFF
--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -786,7 +786,7 @@ func (c *Controller) initializeNFTablesRules(ctx context.Context) error {
 			Name:    ipv6SIPSet,
 			KeyType: nftables.TypeIP6Addr,
 		}
-		// 填充 sets
+		// populate sets
 		if err := c.populateNFTablesSets(ctx, nft, table, destV4IPPortSet, srcV4IPSet, destV6IPPortSet, srcV6IPSet); err != nil {
 			return err
 		}
@@ -1208,7 +1208,7 @@ func (c *Controller) updateNFTablesSets(ctx context.Context) error {
 		Family: nftables.TableFamilyINet,
 	}
 
-	// 获取现有表
+	// get tables
 	tables, err := nft.ListTables()
 	if err != nil {
 		return fmt.Errorf("failed to list tables: %v", err)
@@ -1221,21 +1221,20 @@ func (c *Controller) updateNFTablesSets(ctx context.Context) error {
 			break
 		}
 	}
-
+	// If the table does not exist, it needs to be reinitialized
 	if !tableExists {
-		// 如果表不存在，需要重新初始化
 		logger.Info("Table does not exist, performing full initialization")
 		c.initialized = false
 		return c.syncNFTablesRules(ctx)
 	}
 
-	// 获取现有 sets
+	// Get existing sets
 	sets, err := nft.GetSets(table)
 	if err != nil {
 		return fmt.Errorf("failed to get sets: %v", err)
 	}
 
-	// 检查并删除现有 sets
+	// Check and delete existing sets
 	var destV4IPPortSet, srcV4IPSet, destV6IPPortSet, srcV6IPSet *nftables.Set
 	var destV4IPPortSetExists, sourceV4IPSetExists, destV6IPPortSetExists, sourceV6IPSetExists bool
 	for _, set := range sets {
@@ -1275,7 +1274,7 @@ func (c *Controller) updateNFTablesSets(ctx context.Context) error {
 		nftables.TypeInetService,
 	)
 	if err != nil {
-		klog.ErrorS(err, "can not create v4 concat type")
+		klog.ErrorS(err, "can not create v6 concat type for recreate sets")
 		return err
 	}
 

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -946,7 +946,7 @@ func (c *Controller) initializeNFTablesRules(ctx context.Context) error {
 			Chain: chain,
 			Exprs: []expr.Any{
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
-				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV4}},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV6}},
 				&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
 				&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 24, Len: 16},
@@ -963,7 +963,7 @@ func (c *Controller) initializeNFTablesRules(ctx context.Context) error {
 			Chain: chain,
 			Exprs: []expr.Any{
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
-				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV4}},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV6}},
 				&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_UDP}},
 				&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 24, Len: 16},
@@ -1119,7 +1119,7 @@ func (c *Controller) addDNSRacersWorkaroundRules(nft *nftables.Conn, table *nfta
 			Chain: chain,
 			Exprs: []expr.Any{
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
-				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV4}},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV6}},
 				&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
 				&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 24, Len: 16},
@@ -1136,7 +1136,7 @@ func (c *Controller) addDNSRacersWorkaroundRules(nft *nftables.Conn, table *nfta
 			Chain: chain,
 			Exprs: []expr.Any{
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, Register: 1},
-				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV4}},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.NFPROTO_IPV6}},
 				&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_UDP}},
 				&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 24, Len: 16},
@@ -1270,6 +1270,15 @@ func (c *Controller) updateNFTablesSets(ctx context.Context) error {
 		return err
 	}
 
+	v6ConcatType, err := nftables.ConcatSetType(
+		nftables.TypeIP6Addr,
+		nftables.TypeInetService,
+	)
+	if err != nil {
+		klog.ErrorS(err, "can not create v4 concat type")
+		return err
+	}
+
 	if !destV4IPPortSetExists {
 		logger.Info("daddr_dport_set does not exist, recreating")
 		destV4IPPortSet = &nftables.Set{
@@ -1291,7 +1300,7 @@ func (c *Controller) updateNFTablesSets(ctx context.Context) error {
 		destV6IPPortSet = &nftables.Set{
 			Table:   table,
 			Name:    ipv6DaddrDportSet,
-			KeyType: concatType,
+			KeyType: v6ConcatType,
 		}
 	}
 	if !sourceV6IPSetExists {

--- a/pkg/networkpolicy/controller.go
+++ b/pkg/networkpolicy/controller.go
@@ -982,7 +982,7 @@ func (c *Controller) initializeNFTablesRules(ctx context.Context) error {
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, SourceRegister: false, Register: 0x1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: []uint8{unix.NFPROTO_IPV6}},
 				&expr.Payload{DestRegister: 0x1, Base: expr.PayloadBaseNetworkHeader, Offset: 8, Len: 16},
-				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: ipv4SIPSet},
+				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: ipv6SIPSet},
 				queue,
 			},
 		})
@@ -1155,7 +1155,7 @@ func (c *Controller) addDNSRacersWorkaroundRules(nft *nftables.Conn, table *nfta
 				&expr.Meta{Key: expr.MetaKeyNFPROTO, SourceRegister: false, Register: 0x1},
 				&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: []uint8{unix.NFPROTO_IPV6}},
 				&expr.Payload{DestRegister: 0x1, Base: expr.PayloadBaseNetworkHeader, Offset: 8, Len: 16},
-				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: ipv4SIPSet},
+				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: ipv6SIPSet},
 				queue,
 			},
 		})


### PR DESCRIPTION
## Overview
This PR introduces performance optimizations for network policy implementation by:

1. Implementing precise traffic filtering using IP + Port combinations
2. Optimizing NFTables initialization to a single startup event

## Changes
### Traffic Filtering Enhancement
- Added new NFTables sets for IP+Port filtering
```go
const (
    ipv4DaddrDportSet = "v4_dadp_set"
    ipv6DaddrDportSet = "v6_dadp_set"
)
```
- Implemented targeted packet filtering to reduce unnecessary userspace processing
- Only packets matching network policy criteria are forwarded to NFQueue

### NFTables Optimization
- Moved NFTables rule initialization to startup phase
- Subsequent updates only modify set contents
- Reduced runtime overhead by eliminating frequent rule updates

### Example
```shell
nft list table inet kube-network-policies
                                                        
table inet kube-network-policies {
        set v4_dadp_set {
                type ipv4_addr . inet_service
        }

        set v4_sip_set {
                type ipv4_addr
        }

        set v6_dadp_set {
                type ipv6_addr . inet_service
        }

        set v6_sip_set {
                type ipv6_addr
        }

        chain postrouting {
                type filter hook postrouting priority 95; policy accept;
                udp dport domain accept
                meta l4proto ipv6-icmp accept
                skuid "root" accept
                ct state established,related accept
                ip daddr . tcp dport @v4_dadp_set queue num 98 bypass
                ip daddr . udp dport @v4_dadp_set queue num 98 bypass
                ip saddr @v4_sip_set queue num 98 bypass
                ip6 daddr . tcp dport @v6_dadp_set queue num 98 bypass
                ip6 daddr . udp dport @v6_dadp_set queue num 98 bypass
                ip6 saddr @v4_sip_set queue num 98 bypass
        }

        chain prerouting {
                type filter hook prerouting priority -95; policy accept;
                meta l4proto != udp accept
                udp dport != domain accept
                ip daddr . tcp dport @v4_dadp_set queue num 98 bypass
                ip daddr . udp dport @v4_dadp_set queue num 98 bypass
                ip saddr @v4_sip_set queue num 98 bypass
                ip6 daddr . tcp dport @v6_dadp_set queue num 98 bypass
                ip6 daddr . udp dport @v6_dadp_set queue num 98 bypass
                ip6 saddr @v6_sip_set queue num 98 bypass
        }
}
```