### PR TITLE
avoid kindnet network policies

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,6 +125,8 @@ jobs:
         /usr/local/bin/kind load docker-image registry.k8s.io/networking/kube-network-policies:test --name ${{ env.KIND_CLUSTER_NAME}}
         sed -i s#registry.k8s.io/networking/kube-network-policies.*#registry.k8s.io/networking/kube-network-policies:test# install.yaml
         /usr/local/bin/kubectl apply -f ./install.yaml
+        # stop kindnet of checking network policies
+        kubectl -n kube-system delete clusterrolebinding kindnet
 
     - name: Get Cluster status
       run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,13 +120,13 @@ jobs:
 
     - name: Install kube-network-policies
       run: |
+        # stop kindnet of applying network policies
+        kubectl -n kube-system set image ds kindnet kindnet-cni=docker.io/kindest/kindnetd:v20230809-80a64d96
         # preload kube-network-policies image
         docker load --input kube-network-policies-image.tar
         /usr/local/bin/kind load docker-image registry.k8s.io/networking/kube-network-policies:test --name ${{ env.KIND_CLUSTER_NAME}}
         sed -i s#registry.k8s.io/networking/kube-network-policies.*#registry.k8s.io/networking/kube-network-policies:test# install.yaml
         /usr/local/bin/kubectl apply -f ./install.yaml
-        # stop kindnet of checking network policies
-        kubectl -n kube-system delete clusterrolebinding kindnet
 
     - name: Get Cluster status
       run: |

--- a/.github/workflows/npa.yml
+++ b/.github/workflows/npa.yml
@@ -109,6 +109,8 @@ jobs:
 
     - name: Install kube-network-policies
       run: |
+        # stop kindnet of applying network policies
+        kubectl -n kube-system set image ds kindnet kindnet-cni=docker.io/kindest/kindnetd:v20230809-80a64d96
         /usr/local/bin/kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/main/config/crd/experimental/policy.networking.k8s.io_adminnetworkpolicies.yaml
         /usr/local/bin/kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/main/config/crd/experimental/policy.networking.k8s.io_baselineadminnetworkpolicies.yaml
         # preload kube-network-policies image
@@ -116,8 +118,6 @@ jobs:
         /usr/local/bin/kind load docker-image registry.k8s.io/networking/kube-network-policies:test --name ${{ env.KIND_CLUSTER_NAME}}
         sed -i s#registry.k8s.io/networking/kube-network-policies.*#registry.k8s.io/networking/kube-network-policies:test# install-anp.yaml
         /usr/local/bin/kubectl apply -f ./install-anp.yaml
-        # stop kindnet of checking network policies
-        kubectl -n kube-system delete clusterrolebinding kindnet
 
     - name: Get Cluster status
       run: |

--- a/.github/workflows/npa.yml
+++ b/.github/workflows/npa.yml
@@ -116,6 +116,8 @@ jobs:
         /usr/local/bin/kind load docker-image registry.k8s.io/networking/kube-network-policies:test --name ${{ env.KIND_CLUSTER_NAME}}
         sed -i s#registry.k8s.io/networking/kube-network-policies.*#registry.k8s.io/networking/kube-network-policies:test# install-anp.yaml
         /usr/local/bin/kubectl apply -f ./install-anp.yaml
+        # stop kindnet of checking network policies
+        kubectl -n kube-system delete clusterrolebinding kindnet
 
     - name: Get Cluster status
       run: |

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -136,6 +136,9 @@ EOF
   # Patch kube-proxy to set the verbosity level
   kubectl patch -n kube-system daemonset/kube-proxy \
     --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--v='"${KIND_CLUSTER_LOG_LEVEL}"'" }]'
+    
+  # stop kindnet of applying network policies
+  kubectl -n kube-system set image ds kindnet kindnet-cni=docker.io/kindest/kindnetd:v20230809-80a64d96
 }
 
 # run e2es with ginkgo-e2e.sh
@@ -208,8 +211,6 @@ run_tests() {
 }
 
 install_kube_network_policy() {
-  # stop kindnet of checking network policies
-  kubectl -n kube-system delete clusterrolebinding kindnet
   # Install kube-network-policies
   export IMAGE_NAME="registry.k8s.io/networking/kube-network-policies"
   # Build the image

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -34,6 +34,9 @@ EOF
   printf '%s' "${_install}" | kubectl apply -f -
   kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-network-policies
 
+  # stop kindnet of checking network policies
+  kubectl -n kube-system delete clusterrolebinding kindnet
+  
   # Expose a webserver in the default namespace
   kubectl run web --image=httpd:2 --labels="app=web" --expose --port=80
 

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -34,8 +34,8 @@ EOF
   printf '%s' "${_install}" | kubectl apply -f -
   kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-network-policies
 
-  # stop kindnet of checking network policies
-  kubectl -n kube-system delete clusterrolebinding kindnet
+  # stop kindnet of applying network policies
+  kubectl -n kube-system set image ds kindnet kindnet-cni=docker.io/kindest/kindnetd:v20230809-80a64d96
   
   # Expose a webserver in the default namespace
   kubectl run web --image=httpd:2 --labels="app=web" --expose --port=80


### PR DESCRIPTION
kindnet now implements network policies that can
break the signal from the e2e tests.
Just removing the serviceaccount avoids the agents can receive the information necessary, this is better than removing the kindnet ds entirely because it taints the nodes as not ready.