### PR TITLE
add scalability tests for ipcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	rm -rf "$(OUT_DIR)/"
 
 test:
-	CGO_ENABLED=1 go test -v -race -count 1 ./...
+	CGO_ENABLED=1 go test -short -v -race -count 1 ./...
 
 lint:
 	hack/lint.sh

--- a/pkg/ipcache/etcd.go
+++ b/pkg/ipcache/etcd.go
@@ -110,6 +110,7 @@ func NewEtcdStore(listenURL, etcdDir string, opts ...EtcdOption) (*EtcdStore, er
 	cfg := embed.NewConfig()
 	cfg.Dir = etcdDir
 	cfg.LogLevel = "error"
+	cfg.UnsafeNoFsync = true
 	// Disable peer communication as we're running a single-member cluster.
 	cfg.ListenPeerUrls = []url.URL{}
 


### PR DESCRIPTION
Trying to get some numbers emulating multiple dimensions

```
   /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:826: Initial server disk usage: 141408.00 KB
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:874: --- Scalability Metrics ---
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:875: Number of clients: 1
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:876: Number of namespaces: 1
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:877: Number of pods: 10000
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:880: Average propagation delay: 642.996592ms
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:888: Server memory usage (Alloc): 34979.24 KB
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:889: Server disk usage difference: 6.96 KB
    /usr/local/google/home/aojea/src/kube-network-policies/pkg/ipcache/integration_test.go:898: Client 0 disk usage (BoltDB): 1024.00 KB
```


let's see how this will work in one of those megaclusters , assume 128k nodes, and 10 pods per node