### PR TITLE
Fix push for npa-v1alpha2 as it was only building before

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ image-push-kube-ip-tracker-standard: build-kube-ip-tracker-standard
 images-build: ensure-buildx image-build-standard image-build-npa-v1alpha1 image-build-npa-v1alpha2 image-build-iptracker image-build-kube-ip-tracker-standard
 
 # Build and push all multi-platform image variants to the registry
-images-push: ensure-buildx image-push-standard image-push-npa-v1alpha1 image-build-npa-v1alpha2 image-push-iptracker image-push-kube-ip-tracker-standard
+images-push: ensure-buildx image-push-standard image-push-npa-v1alpha1 image-push-npa-v1alpha2 image-push-iptracker image-push-kube-ip-tracker-standard
 
 # The main release target, which pushes all images
 release: images-push


### PR DESCRIPTION
You can see e.g. here https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kube-network-policies-image/1960723853059559424/build-log.txt that there is logs for
`pushing manifest for gcr.io/k8s-staging-networking/kube-network-policies:v20250827-fa24992-npa-v1alpha1`
but no logs for `v1alpha2`