### PR TITLE
Bump images to newly released v0.9.1

### DIFF
--- a/install-anp.yaml
+++ b/install-anp.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.8.0-npa-v1alpha1
+        image: registry.k8s.io/networking/kube-network-policies:v0.8.0
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install-cnp.yaml
+++ b/install-cnp.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.8.0-npa-v1alpha2
+        image: registry.k8s.io/networking/kube-network-policies:v0.9.1-npa-v1alpha2
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install-iptracker.yaml
+++ b/install-iptracker.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: kube-ip-tracker
       containers:
       - name: kube-ip-tracker
-        image: registry.k8s.io/networking/kube-ip-tracker:v0.1.0
+        image: registry.k8s.io/networking/kube-ip-tracker:v0.9.1
         args:
         - /bin/kube-ip-tracker
         - --listen-address=http://0.0.0.0:10999
@@ -154,7 +154,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.8.0-iptracker
+        image: registry.k8s.io/networking/kube-network-policies:v0.9.1-iptracker
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install.yaml
+++ b/install.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.8.0
+        image: registry.k8s.io/networking/kube-network-policies:v0.9.1
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)


### PR DESCRIPTION
ANP image wasn't released, hence the latest working version for it is v0.8.0.

New images are from https://github.com/kubernetes/k8s.io/pull/8451/files