### PR TITLE
Change Allow => Accept to match upstream v1alpha2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,8 @@ require (
 	k8s.io/component-helpers v0.33.4
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
-	sigs.k8s.io/network-policy-api v0.1.8-0.20250826165010-d5cee02b3c1c
+	// Temporarily reference latest network-policy-api in anticipation of Beta.
+	sigs.k8s.io/network-policy-api v0.1.8-0.20250912163209-de1b4e9d7da6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 h1:hwvWFiBzdWw1FhfY1FooPn3kzWuJ8
 k8s.io/utils v0.0.0-20250604170112-4c0f3b243397/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/network-policy-api v0.1.8-0.20250826165010-d5cee02b3c1c h1:ySTDTqw3flKypZ4OnU2Q1lY/MzCBbONPVL6Rmx4BRAQ=
-sigs.k8s.io/network-policy-api v0.1.8-0.20250826165010-d5cee02b3c1c/go.mod h1:QIWX6Th2h0SmCwOwa1+9Urs0W+WDJGL5rujAPUemdkk=
+sigs.k8s.io/network-policy-api v0.1.8-0.20250912163209-de1b4e9d7da6 h1:UGDfNgUgHp7RtBaV9Tp01FyS5Bh05ExpLpYjOVwatVY=
+sigs.k8s.io/network-policy-api v0.1.8-0.20250912163209-de1b4e9d7da6/go.mod h1:QIWX6Th2h0SmCwOwa1+9Urs0W+WDJGL5rujAPUemdkk=
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=

--- a/plugins/npa-v1alpha2/clusternetworkpolicy.go
+++ b/plugins/npa-v1alpha2/clusternetworkpolicy.go
@@ -260,7 +260,7 @@ func evaluateClusterNetworkPolicyPort(
 // actionToVerdict translates a CNP action into an internal Verdict.
 func actionToVerdict(action npav1alpha2.ClusterNetworkPolicyRuleAction) api.Verdict {
 	switch action {
-	case npav1alpha2.ClusterNetworkPolicyRuleActionAllow:
+	case npav1alpha2.ClusterNetworkPolicyRuleActionAccept:
 		return api.VerdictAccept
 	case npav1alpha2.ClusterNetworkPolicyRuleActionDeny:
 		return api.VerdictDeny

--- a/plugins/npa-v1alpha2/clusternetworkpolicy_test.go
+++ b/plugins/npa-v1alpha2/clusternetworkpolicy_test.go
@@ -157,7 +157,7 @@ func Test_ClusterNetworkPolicy_Evaluation(t *testing.T) {
 	adminAllowEgressToNSBar := makeClusterNetworkPolicy("admin-allow-egress-to-ns-bar", npav1alpha2.AdminTier, 50, func(p *npav1alpha2.ClusterNetworkPolicy) {
 		p.Spec.Subject = npav1alpha2.ClusterNetworkPolicySubject{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "ns-foo"}}}
 		p.Spec.Egress = []npav1alpha2.ClusterNetworkPolicyEgressRule{{
-			Action: npav1alpha2.ClusterNetworkPolicyRuleActionAllow,
+			Action: npav1alpha2.ClusterNetworkPolicyRuleActionAccept,
 			To:     []npav1alpha2.ClusterNetworkPolicyEgressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "bar"}}}},
 		}}
 	})
@@ -174,7 +174,7 @@ func Test_ClusterNetworkPolicy_Evaluation(t *testing.T) {
 	baselineAllowIngressFromNSFoo := makeClusterNetworkPolicy("baseline-allow-ingress-from-ns-foo", npav1alpha2.BaselineTier, 50, func(p *npav1alpha2.ClusterNetworkPolicy) {
 		p.Spec.Subject = npav1alpha2.ClusterNetworkPolicySubject{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "bar"}}}
 		p.Spec.Ingress = []npav1alpha2.ClusterNetworkPolicyIngressRule{{
-			Action: npav1alpha2.ClusterNetworkPolicyRuleActionAllow,
+			Action: npav1alpha2.ClusterNetworkPolicyRuleActionAccept,
 			From:   []npav1alpha2.ClusterNetworkPolicyIngressPeer{{Namespaces: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "foo"}}}},
 		}}
 	})


### PR DESCRIPTION
Updates the implementation to match the upstream changes for v1alpha2:

```text
commit de1b4e9d7da6c608a6a5e72c076c7decbe503e60 (upstream/main, upstream/HEAD)
Merge: 8d10833 c95036e
Author: Kubernetes Prow Robot <20407524+k8s-ci-robot@users.noreply.github.com>
Date:   Fri Sep 12 09:32:09 2025 -0700

    Merge pull request #318 from bowei/pr-allow-to-accept
    
    Allow => Accept
```