### PR TITLE
make firewall enforcer for current connections optional

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -74,6 +74,7 @@ spec:
         - --hostname-override=$(MY_NODE_NAME)
         - --v=2
         - --nfqueue-id=98
+        - --firewall-enforcer-period=0
         volumeMounts:
         - name: nri-plugin
           mountPath: /var/run/nri

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -18,13 +18,14 @@ import (
 
 // Options contains the common command-line options.
 type Options struct {
-	Kubeconfig          string
-	FailOpen            bool
-	QueueID             int
-	MetricsBindAddress  string
-	HostnameOverride    string
-	NetfilterBug1766Fix bool
-	DisableNRI          bool
+	Kubeconfig             string
+	FailOpen               bool
+	QueueID                int
+	MetricsBindAddress     string
+	HostnameOverride       string
+	NetfilterBug1766Fix    bool
+	DisableNRI             bool
+	FirewallEnforcerPeriod int
 }
 
 // NewOptions creates a new Options object with default values.
@@ -41,7 +42,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.HostnameOverride, "hostname-override", "", "If non-empty, will be used as the name of the Node that kube-network-policies is running on. If unset, the node name is assumed to be the same as the node's hostname.")
 	fs.BoolVar(&o.NetfilterBug1766Fix, "netfilter-bug-1766-fix", true, "If set, process DNS packets on the PREROUTING hooks to avoid the race condition on the conntrack subsystem, not needed for kernels 6.12+ (see https://bugzilla.netfilter.org/show_bug.cgi?id=1766)")
 	fs.BoolVar(&o.DisableNRI, "disable-nri", false, "If set, disable NRI, that is used to get the Pod IP information directly from the runtime to avoid the race explained in https://issues.k8s.io/85966")
-
+	fs.IntVar(&o.FirewallEnforcerPeriod, "firewall-enforcer-period", 0, "If set, the period for the firewall enforcer to run. It ensures that existing connections comply with current network policies. If 0, the firewall enforcer is disabled.")
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: kube-network-policies [options]\n\n")
 		fs.PrintDefaults()

--- a/tests/e2e_standard.bats
+++ b/tests/e2e_standard.bats
@@ -14,7 +14,7 @@ setup_file() {
   # Load the Docker image into the kind cluster
   kind load docker-image "$REGISTRY/$IMAGE_NAME:$TAG" --name "$CLUSTER_NAME"
 
-  _install=$(sed -e "s#$REGISTRY/$IMAGE_NAME.*#$REGISTRY/$IMAGE_NAME:$TAG#" -e "s/--v=2/--v=4/" < "$BATS_TEST_DIRNAME"/../install.yaml)
+  _install=$(sed -e "s#$REGISTRY/$IMAGE_NAME.*#$REGISTRY/$IMAGE_NAME:$TAG#" -e "s/--v=2/--v=4/" -e "s/--firewall-enforcer-period=0/--firewall-enforcer-period=15/" < "$BATS_TEST_DIRNAME"/../install.yaml)
   printf '%s' "${_install}" | kubectl apply -f -
   kubectl wait --for=condition=ready pods --namespace=kube-system -l k8s-app=kube-network-policies
 }
@@ -285,5 +285,5 @@ spec:
 EOF
 
   # Wait for the client pod to complete, which indicates the connection was dropped
-  kubectl -n dev wait --for=condition=Ready=False pod/client --timeout=65s
+  kubectl -n dev wait --for=condition=Ready=False pod/client --timeout=30s
 }


### PR DESCRIPTION
besides we discussed and deccided that is the more logical behavior, the previous behavior of not impacting existing connections is widely used even outside of kubernetes, so in order to avoid breaking existing behavior we rollout this new functionality behind a flag that allow users to define the period of time they want to use to enforce the network policies on existing connections. The default value is zero, that disables this feature.