### PR TITLE
The Logging Network policy handlers is independent of the log level

### DIFF
--- a/pkg/networkpolicy/logging.go
+++ b/pkg/networkpolicy/logging.go
@@ -64,7 +64,7 @@ func logPacket(ctx context.Context, direction string, p *network.Packet, srcPod,
 		dstPodStr = dstPod.Namespace.Name + "/" + dstPod.Name
 	}
 
-	logger.V(2).Info("Evaluating packet",
+	logger.Info("Evaluating packet",
 		"direction", direction,
 		"srcPod", srcPodStr,
 		"dstPod", dstPodStr,


### PR DESCRIPTION
The intention is that the consumer uses the logging handler at the log level they please, by inserting it in the pipeline. Hence, the logging handler should not make any assumption about verbosity levels 

Spotted by @danwinship  in https://github.com/kubernetes-sigs/kindnet/pull/11#discussion_r2432484298