### PR TITLE
Support s390x build (IBM Z)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
 # Use an ARG to select which build target to compile and use
 ARG TARGET_BUILD=standard
-ARG BINARY_NAME=kube-network-policies-${TARGET_BUILD}
 
 FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 WORKDIR /src
+
+# Get target architecture for cross-compilation
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGET_BUILD
+
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-# Build the specific binary based on the build argument
-ARG TARGET_BUILD
-RUN make build-${TARGET_BUILD}
+# Build the specific binary based on the build argument and target architecture
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-${TARGET_BUILD}
 
 # STEP 2: Build small image
 FROM gcr.io/distroless/static-debian12
-ARG BINARY_NAME
-COPY --from=builder /src/bin/${BINARY_NAME} /bin/netpol
+ARG TARGET_BUILD
+COPY --from=builder /src/bin/kube-network-policies-${TARGET_BUILD} /bin/netpol
 
 # The entrypoint is always the same, regardless of the build
 CMD ["/bin/netpol"]

--- a/Dockerfile.iptracker
+++ b/Dockerfile.iptracker
@@ -1,22 +1,25 @@
 # Use an ARG to select which build target to compile and use
 ARG TARGET_BUILD=standard
-ARG BINARY_NAME=kube-ip-tracker-${TARGET_BUILD}
 
 FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 
 WORKDIR /src
 
+# Get target architecture for cross-compilation
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGET_BUILD
+
 COPY . .
 RUN go mod download
 
-# Build the specific binary based on the build argument
-ARG TARGET_BUILD
-RUN make build-kube-ip-tracker-${TARGET_BUILD}
+# Build the specific binary based on the build argument and target architecture
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build-kube-ip-tracker-${TARGET_BUILD}
 
 # STEP 2: Build small image
 FROM gcr.io/distroless/static-debian12
-ARG BINARY_NAME
-COPY --from=builder /src/bin/${BINARY_NAME} /bin/kube-ip-tracker
+ARG TARGET_BUILD
+COPY --from=builder /src/bin/kube-ip-tracker-${TARGET_BUILD} /bin/kube-ip-tracker
 
 # The entrypoint is always the same, regardless of the build
 CMD ["/bin/kube-ip-tracker"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export GO111MODULE CGO_ENABLED
 IMAGE_NAME?=kube-network-policies
 REGISTRY?=gcr.io/k8s-staging-networking
 TAG?=$(shell echo "$$(date +v%Y%m%d)-$$(git describe --always --dirty)")
-PLATFORMS?=linux/amd64,linux/arm64
+PLATFORMS?=linux/amd64,linux/arm64,linux/s390x
 
 .PHONY: all build build-standard build-npa-v1alpha1 build-npa-v1alpha2 build-iptracker build-kube-ip-tracker-standard
 
@@ -18,23 +18,23 @@ build: build-standard build-npa-v1alpha1 build-npa-v1alpha2 build-iptracker buil
 
 build-standard:
 	@echo "Building standard binary..."
-	go build -o ./bin/kube-network-policies-standard ./cmd/kube-network-policies/standard
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/kube-network-policies-standard ./cmd/kube-network-policies/standard
 
 build-npa-v1alpha1:
 	@echo "Building npa-v1alpha1 binary..."
-	go build -o ./bin/kube-network-policies-npa-v1alpha1 ./cmd/kube-network-policies/npa-v1alpha1
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/kube-network-policies-npa-v1alpha1 ./cmd/kube-network-policies/npa-v1alpha1
 
 build-npa-v1alpha2:
 	@echo "Building npa-v1alpha2 binary..."
-	go build -o ./bin/kube-network-policies-npa-v1alpha2 ./cmd/kube-network-policies/npa-v1alpha2
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/kube-network-policies-npa-v1alpha2 ./cmd/kube-network-policies/npa-v1alpha2
 
 build-iptracker:
 	@echo "Building iptracker binary..."
-	go build -o ./bin/kube-network-policies-iptracker ./cmd/kube-network-policies/iptracker
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/kube-network-policies-iptracker ./cmd/kube-network-policies/iptracker
 
 build-kube-ip-tracker-standard:
 	@echo "Building kube-ip-tracker binary..."
-	go build -o ./bin/kube-ip-tracker-standard ./cmd/kube-ip-tracker/standard
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o ./bin/kube-ip-tracker-standard ./cmd/kube-ip-tracker/standard
 
 clean:
 	rm -rf "$(OUT_DIR)/"
@@ -118,6 +118,7 @@ image-push-iptracker: build-iptracker
 image-push-kube-ip-tracker-standard: build-kube-ip-tracker-standard
 	docker buildx build . -f Dockerfile.iptracker \
 		--build-arg TARGET_BUILD=standard \
+		--platform="${PLATFORMS}" \
 		--tag="${REGISTRY}/kube-ip-tracker:$(TAG)" \
 		--push
 


### PR DESCRIPTION
Also:
Fix ARM cross (the binary had wrong arch)
Add multi arch support for `kube-ip-tracker` 

Fixes https://github.com/kubernetes-sigs/kube-network-policies/issues/263