### PR TITLE
implement egress policies from Pod to Node

### DIFF
--- a/pkg/dataplane/controller.go
+++ b/pkg/dataplane/controller.go
@@ -737,6 +737,75 @@ func (c *Controller) syncNFTablesRules(ctx context.Context) error {
 		},
 	})
 
+	// INPUT chain: evaluate pod-to-host (egress toward the node itself) network policies.
+	// Only the first packet of new connections (ct state new) is queued.
+	// TODO: investigate why if we process not only new, e2e tests start failing.
+	inputChain := nft.AddChain(&nftables.Chain{
+		Name:    "input",
+		Table:   table,
+		Type:    nftables.ChainTypeFilter,
+		Hooknum: nftables.ChainHookInput,
+		// Run after IPVS LOCAL_IN hooks (which use srcnat-2 and srcnat-1 priorities).
+		// https://elixir.bootlin.com/linux/v5.10/source/net/netfilter/ipvs/ip_vs_core.c#L2249
+		Priority: nftables.ChainPriorityRef(*nftables.ChainPriorityNATSource + 1),
+	})
+
+	// iifname "lo" accept - bypass all loopback traffic to avoid blocking node-to-itself traffic.
+	nft.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: inputChain,
+		Exprs: []expr.Any{
+			&expr.Meta{Key: expr.MetaKeyIIFNAME, SourceRegister: false, Register: 0x1},
+			&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: []byte("lo\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")},
+			&expr.Verdict{Kind: expr.VerdictAccept},
+		},
+	})
+
+	if !divertAll {
+		// ip saddr @podips-v4 ct state new queue
+		nft.AddRule(&nftables.Rule{
+			Table: table,
+			Chain: inputChain,
+			Exprs: []expr.Any{
+				&expr.Meta{Key: expr.MetaKeyNFPROTO, SourceRegister: false, Register: 0x1},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: []uint8{unix.NFPROTO_IPV4}},
+				&expr.Payload{DestRegister: 0x1, Base: expr.PayloadBaseNetworkHeader, Offset: 12, Len: 4},
+				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: "podips-v4"},
+				&expr.Ct{Register: 0x1, SourceRegister: false, Key: expr.CtKeySTATE},
+				&expr.Bitwise{SourceRegister: 0x1, DestRegister: 0x1, Len: 0x4, Mask: binaryutil.NativeEndian.PutUint32(expr.CtStateBitNEW), Xor: []byte{0x0, 0x0, 0x0, 0x0}},
+				&expr.Cmp{Op: expr.CmpOpNeq, Register: 0x1, Data: []byte{0x0, 0x0, 0x0, 0x0}},
+				queue,
+			},
+		})
+		// ip6 saddr @podips-v6 ct state new queue
+		nft.AddRule(&nftables.Rule{
+			Table: table,
+			Chain: inputChain,
+			Exprs: []expr.Any{
+				&expr.Meta{Key: expr.MetaKeyNFPROTO, SourceRegister: false, Register: 0x1},
+				&expr.Cmp{Op: expr.CmpOpEq, Register: 0x1, Data: []uint8{unix.NFPROTO_IPV6}},
+				&expr.Payload{DestRegister: 0x1, Base: expr.PayloadBaseNetworkHeader, Offset: 8, Len: 16},
+				&expr.Lookup{SourceRegister: 0x1, DestRegister: 0x0, SetName: "podips-v6"},
+				&expr.Ct{Register: 0x1, SourceRegister: false, Key: expr.CtKeySTATE},
+				&expr.Bitwise{SourceRegister: 0x1, DestRegister: 0x1, Len: 0x4, Mask: binaryutil.NativeEndian.PutUint32(expr.CtStateBitNEW), Xor: []byte{0x0, 0x0, 0x0, 0x0}},
+				&expr.Cmp{Op: expr.CmpOpNeq, Register: 0x1, Data: []byte{0x0, 0x0, 0x0, 0x0}},
+				queue,
+			},
+		})
+	} else {
+		// ct state new queue
+		nft.AddRule(&nftables.Rule{
+			Table: table,
+			Chain: inputChain,
+			Exprs: []expr.Any{
+				&expr.Ct{Register: 0x1, SourceRegister: false, Key: expr.CtKeySTATE},
+				&expr.Bitwise{SourceRegister: 0x1, DestRegister: 0x1, Len: 0x4, Mask: binaryutil.NativeEndian.PutUint32(expr.CtStateBitNEW), Xor: []byte{0x0, 0x0, 0x0, 0x0}},
+				&expr.Cmp{Op: expr.CmpOpNeq, Register: 0x1, Data: []byte{0x0, 0x0, 0x0, 0x0}},
+				queue,
+			},
+		})
+	}
+
 	if c.config.NetfilterBug1766Fix {
 		c.addDNSRacersWorkaroundRules(nft, table, divertAll)
 	}

--- a/pkg/dataplane/controller_test.go
+++ b/pkg/dataplane/controller_test.go
@@ -286,6 +286,13 @@ table inet kube-network-policies {
 		ct label set 28
 	}
 
+	chain input {
+		type filter hook input priority srcnat + 1; policy accept;
+		iifname "lo" accept
+		ip saddr @podips-v4 ct state new queue flags bypass to 102
+		ip6 saddr @podips-v6 ct state new queue flags bypass to 102
+	}
+
 	chain prerouting {
 		type filter hook prerouting priority dstnat + 5; policy accept;
 		meta l4proto != udp accept
@@ -328,6 +335,11 @@ table inet kube-network-policies {
 		queue to 102
 		ct label set 28
 	}
+	chain input {
+		type filter hook input priority srcnat + 1; policy accept;
+		iifname "lo" accept
+		ct state new queue to 102
+	}
 	chain prerouting {
 		type filter hook prerouting priority dstnat + 5; policy accept;
 		meta l4proto != udp accept
@@ -368,6 +380,11 @@ table inet kube-network-policies {
 		ct label 28 ct state established,related counter packets 0 bytes 0 accept
 		queue to 102
 		ct label set 28
+	}
+	chain input {
+		type filter hook input priority srcnat + 1; policy accept;
+		iifname "lo" accept
+		ct state new queue to 102
 	}
 }
 `,


### PR DESCRIPTION
We were evaluating traffic only on the POSTROUTING hook. However, we also need to evaluate packets going from Pods to Nodes.

Instead of moving policy evaluation to PREROUTING, this change extends the current logic by adding INPUT hook processing to inspect traffic that:

is not host-originated,
is in ct state NEW, and
is directed to the host itself

Fixes: #283