### PR TITLE
Bump golangci-lint to 2.11.4

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -7,4 +7,4 @@ set -o pipefail
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 cd $REPO_ROOT
-docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.8.0 golangci-lint run -v
+docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v2.11.4 golangci-lint run -v


### PR DESCRIPTION
This updates the version of golangci-lint used for compatibility with Go 1.26 (#343).