### PR TITLE
Update repository manifests to v1.1.0

### DIFF
--- a/charts/kube-network-policies/values.yaml
+++ b/charts/kube-network-policies/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: registry.k8s.io/networking/kube-network-policies
   pullPolicy: IfNotPresent
-  tag: "v0.6.0"
+  tag: "v1.1.0"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/install-anp.yaml
+++ b/install-anp.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v1.0.0
+        image: registry.k8s.io/networking/kube-network-policies:v1.1.0
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install-cnp.yaml
+++ b/install-cnp.yaml
@@ -77,7 +77,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v1.0.0-npa-v1alpha2
+        image: registry.k8s.io/networking/kube-network-policies:v1.1.0-npa-v1alpha2
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install-iptracker.yaml
+++ b/install-iptracker.yaml
@@ -154,7 +154,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v1.0.0-iptracker
+        image: registry.k8s.io/networking/kube-network-policies:v1.1.0-iptracker
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)

--- a/install.yaml
+++ b/install.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v1.0.0
+        image: registry.k8s.io/networking/kube-network-policies:v1.1.0
         args:
         - /bin/netpol
         - --hostname-override=$(MY_NODE_NAME)


### PR DESCRIPTION
/hold

This PR updates the repository manifests to use the new release images.

Depends on image promotion PR: https://github.com/kubernetes/k8s.io/pull/9681

Instructions: Please do not unhold/merge this PR until the image promotion PR is merged and the promoted images are live.