### PR TITLE
networkpolicy: exclude host network pods from managed IPs

### DIFF
--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -160,6 +160,8 @@ func (s *StandardNetworkPolicy) ManagedIPs(ctx context.Context) ([]netip.Addr, b
 }
 
 // getLocalPodsForNetworkPolicy finds all pods on the current node that are selected by a given policy.
+// Pods on the host network are skipped: they share the Node IP address, so they are not subject to
+// NetworkPolicies and their addresses must never reach the dataplane enforcement sets.
 func (s *StandardNetworkPolicy) getLocalPodsForNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy) []*v1.Pod {
 	if networkPolicy == nil {
 		return nil
@@ -175,6 +177,9 @@ func (s *StandardNetworkPolicy) getLocalPodsForNetworkPolicy(networkPolicy *netw
 	}
 	result := []*v1.Pod{}
 	for _, pod := range pods {
+		if pod.Spec.HostNetwork {
+			continue
+		}
 		if pod.Spec.NodeName == s.nodeName {
 			result = append(result, pod)
 		}

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -3,12 +3,14 @@ package networkpolicy
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/component-base/logs"
@@ -942,5 +944,54 @@ func TestEvaluator_evaluatePorts(t *testing.T) {
 				t.Errorf("Controller.evaluatePorts() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStandardNetworkPolicy_ManagedIPs(t *testing.T) {
+	// A policy that selects every pod in the namespace.
+	policy := makeNetworkPolicyCustom("select-all", "foo", func(networkPolicy *networkingv1.NetworkPolicy) {
+		networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+	})
+
+	podNetworkPod := makePod("pod-network", "foo", "192.168.1.11")
+	hostNetworkPod := makePod("host-network", "foo", "10.0.0.1")
+	hostNetworkPod.Spec.HostNetwork = true
+
+	remotePod := makePod("remote", "foo", "192.168.2.22")
+	remotePod.Spec.NodeName = "othernode"
+
+	client := fake.NewSimpleClientset()
+	informersFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informersFactory.Core().V1().Pods()
+	networkPolicyInformer := informersFactory.Networking().V1().NetworkPolicies()
+	namespaceInformer := informersFactory.Core().V1().Namespaces()
+
+	if err := networkPolicyInformer.Informer().GetStore().Add(policy); err != nil {
+		t.Fatal(err)
+	}
+	if err := namespaceInformer.Informer().GetStore().Add(makeNamespace("foo")); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []*v1.Pod{podNetworkPod, hostNetworkPod, remotePod} {
+		if err := podInformer.Informer().GetStore().Add(p); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// makePod() places pods on "testnode".
+	evaluator := NewStandardNetworkPolicy("testnode", namespaceInformer, podInformer, networkPolicyInformer)
+
+	ips, divertAll, err := evaluator.ManagedIPs(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if divertAll {
+		t.Error("standard NetworkPolicies must never require diverting all traffic")
+	}
+
+	got := sets.New[netip.Addr](ips...)
+	want := sets.New[netip.Addr](netip.MustParseAddr("192.168.1.11"))
+	if !got.Equal(want) {
+		t.Errorf("ManagedIPs() = %v, want %v (host network pods share the Node IP and must not be enrolled)", got.UnsortedList(), want.UnsortedList())
 	}
 }


### PR DESCRIPTION
Closes #380.

## What this fixes

`getLocalPodsForNetworkPolicy()` returned every local pod selected by a NetworkPolicy, with no `hostNetwork` exclusion. Host network pods report the **Node IP** in `status.podIPs`, so `ManagedIPs()` enrolled Node IPs into the `podips-v4`/`podips-v6` nftables sets and node traffic got sent through policy enforcement.

The rest of the codebase already treats host network pods as out of scope, which is what makes this an asymmetry rather than a design choice:

- `pkg/podinfo/ipresolver.go:33` — `if !ok || pod.Spec.HostNetwork`
- `pkg/podinfo/podinfo.go:60` — `if !ok || pod.Spec.HostNetwork || len(pod.Status.PodIP) == 0`
- `cmd/kube-ip-tracker/standard/main.go:173` — `if pod.Spec.HostNetwork || len(pod.Status.PodIPs) == 0`

## Where the skip goes

In `getLocalPodsForNetworkPolicy()`, as @aojea suggested on the issue, rather than in `ManagedIPs()` itself. That helper has four callers — `ManagedIPs()` plus the three NetworkPolicy informer handlers (add/update/delete) that call `syncCallback()` when a policy selects a local pod. Fixing the helper covers all of them: a policy that only selects host network pods now also stops scheduling dataplane syncs that can have no effect. One skip, no caller left behind.

I checked the sibling evaluators for the same defect before writing this — `AdminNetworkPolicy`, `BaselineAdminNetworkPolicy`, `ClusterNetworkPolicy` and `IPTrackerNetworkPolicy` all return `(nil, true, nil)` (divert-all) and never build an IP set, so `StandardNetworkPolicy` is the only affected evaluator.

## Test

`TestStandardNetworkPolicy_ManagedIPs` covers a select-all policy over three pods: a local pod-network pod, a local `hostNetwork: true` pod, and a pod on another node. It asserts only the pod-network IP is returned, and that `divertAll` stays false.

Verified in both directions — with the skip reverted the new test fails with exactly the reported symptom:

```
--- FAIL: TestStandardNetworkPolicy_ManagedIPs (0.00s)
    ManagedIPs() = [192.168.1.11 10.0.0.1], want [192.168.1.11]
```

With the fix: `go test -race ./pkg/networkpolicy/` passes, and `go test ./...` is green (`gofmt`/`go vet` clean).

Credit to @bjornmage for the report — the source-level diagnosis in the issue was accurate and made this a short patch.