### PR TITLE
skip hostNetwork pods in getLocalPodsForNetworkPolicy

### DIFF
--- a/pkg/networkpolicy/networkpolicy.go
+++ b/pkg/networkpolicy/networkpolicy.go
@@ -175,7 +175,7 @@ func (s *StandardNetworkPolicy) getLocalPodsForNetworkPolicy(networkPolicy *netw
 	}
 	result := []*v1.Pod{}
 	for _, pod := range pods {
-		if pod.Spec.NodeName == s.nodeName {
+		if pod.Spec.NodeName == s.nodeName && !pod.Spec.HostNetwork {
 			result = append(result, pod)
 		}
 	}

--- a/pkg/networkpolicy/networkpolicy_test.go
+++ b/pkg/networkpolicy/networkpolicy_test.go
@@ -3,6 +3,7 @@ package networkpolicy
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -942,5 +943,94 @@ func TestEvaluator_evaluatePorts(t *testing.T) {
 				t.Errorf("Controller.evaluatePorts() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStandardNetworkPolicy_ManagedIPs(t *testing.T) {
+	podLocal := makePod("pod-local", "bar", "192.168.2.22")
+	podHost := makePod("pod-host", "bar", "10.0.0.1")
+	podHost.Spec.HostNetwork = true
+	podOtherNode := makePod("pod-othernode", "bar", "192.168.2.33")
+	podOtherNode.Spec.NodeName = "othernode"
+
+	npDefaultDeny := makeNetworkPolicyCustom("default-deny", "bar",
+		func(networkPolicy *networkingv1.NetworkPolicy) {
+			networkPolicy.Spec.PodSelector = metav1.LabelSelector{}
+			networkPolicy.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeIngress}
+		})
+
+	client := fake.NewSimpleClientset()
+	informersFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informersFactory.Core().V1().Pods()
+	networkPolicyInformer := informersFactory.Networking().V1().NetworkPolicies()
+	namespaceInformer := informersFactory.Core().V1().Namespaces()
+
+	podStore := podInformer.Informer().GetStore()
+	npStore := networkPolicyInformer.Informer().GetStore()
+
+	if err := podStore.Add(podLocal); err != nil {
+		t.Fatalf("unexpected error adding podLocal: %v", err)
+	}
+	if err := podStore.Add(podHost); err != nil {
+		t.Fatalf("unexpected error adding podHost: %v", err)
+	}
+	if err := podStore.Add(podOtherNode); err != nil {
+		t.Fatalf("unexpected error adding podOtherNode: %v", err)
+	}
+	if err := npStore.Add(npDefaultDeny); err != nil {
+		t.Fatalf("unexpected error adding npDefaultDeny: %v", err)
+	}
+
+	evaluator := NewStandardNetworkPolicy("testnode", namespaceInformer, podInformer, networkPolicyInformer)
+
+	ctx := context.Background()
+	ips, divertAll, err := evaluator.ManagedIPs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if divertAll {
+		t.Errorf("expected divertAll to be false, got true")
+	}
+
+	expectedIP := netip.MustParseAddr("192.168.2.22")
+	if len(ips) != 1 || ips[0] != expectedIP {
+		t.Errorf("expected managed IPs [%v], got %v", expectedIP, ips)
+	}
+}
+
+func TestStandardNetworkPolicy_GetLocalPodsForNetworkPolicy(t *testing.T) {
+	podLocal := makePod("pod-local", "bar", "192.168.2.22")
+	podHost := makePod("pod-host", "bar", "10.0.0.1")
+	podHost.Spec.HostNetwork = true
+	podOtherNode := makePod("pod-othernode", "bar", "192.168.2.33")
+	podOtherNode.Spec.NodeName = "othernode"
+
+	np := makeNetworkPolicyCustom("default-deny", "bar",
+		func(networkPolicy *networkingv1.NetworkPolicy) {
+			networkPolicy.Spec.PodSelector = metav1.LabelSelector{}
+		})
+
+	client := fake.NewSimpleClientset()
+	informersFactory := informers.NewSharedInformerFactory(client, 0)
+	podInformer := informersFactory.Core().V1().Pods()
+	networkPolicyInformer := informersFactory.Networking().V1().NetworkPolicies()
+	namespaceInformer := informersFactory.Core().V1().Namespaces()
+
+	podStore := podInformer.Informer().GetStore()
+	if err := podStore.Add(podLocal); err != nil {
+		t.Fatalf("unexpected error adding podLocal: %v", err)
+	}
+	if err := podStore.Add(podHost); err != nil {
+		t.Fatalf("unexpected error adding podHost: %v", err)
+	}
+	if err := podStore.Add(podOtherNode); err != nil {
+		t.Fatalf("unexpected error adding podOtherNode: %v", err)
+	}
+
+	evaluator := NewStandardNetworkPolicy("testnode", namespaceInformer, podInformer, networkPolicyInformer)
+
+	pods := evaluator.getLocalPodsForNetworkPolicy(np)
+	if len(pods) != 1 || pods[0].Name != "pod-local" {
+		t.Errorf("expected local pod [pod-local], got %v", pods)
 	}
 }

--- a/tests/e2e_standard.bats
+++ b/tests/e2e_standard.bats
@@ -329,3 +329,69 @@ EOF
   kubectl delete networkpolicy default-deny-ingress -n prod --ignore-not-found
   rm -f "$TMPFILEIN" "$TMPFILEOUT"
 }
+
+# https://github.com/kubernetes-sigs/kube-network-policies/issues/380
+# https://github.com/kubernetes-sigs/kube-network-policies/issues/379
+@test "hostNetwork pods do not cause node IP leakage into managed IPs" {
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostnet-server
+  namespace: dev
+spec:
+  hostNetwork: true
+  containers:
+  - name: agnhost
+    image: registry.k8s.io/e2e-test-images/agnhost:2.39
+    args:
+    - netexec
+    - --http-port=9999
+EOF
+
+  kubectl -n dev wait --for=condition=ready pod/hostnet-server --timeout=30s
+
+  NODE_NAME=$(kubectl get pod hostnet-server -n dev -o jsonpath='{.spec.nodeName}')
+  NODE_IP=$(kubectl get pod hostnet-server -n dev -o jsonpath='{.status.podIP}')
+
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-client
+  namespace: dev
+spec:
+  nodeName: ${NODE_NAME}
+  containers:
+  - name: busybox
+    image: registry.k8s.io/busybox:1.27
+    command:
+    - sleep
+    - "3600"
+EOF
+
+  kubectl -n dev wait --for=condition=ready pod/test-client --timeout=30s
+
+  kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: dev
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+EOF
+
+  sleep 2
+
+  # Client pod on the same node should be able to connect to hostnet-server on NODE_IP:9999
+  kubectl -n dev exec test-client -- wget -T 5 -q -O - "http://${NODE_IP}:9999/hostname"
+
+  kubectl delete pod hostnet-server -n dev --ignore-not-found
+  kubectl delete pod test-client -n dev --ignore-not-found
+  kubectl delete networkpolicy default-deny-ingress -n dev --ignore-not-found
+}
+
+


### PR DESCRIPTION
#### What this PR does / why we need it
`StandardNetworkPolicy.ManagedIPs()` builds the `podips-v4`/`podips-v6` nftables enforcement sets from local pods selected by `NetworkPolicy` objects. Previously, `getLocalPodsForNetworkPolicy` did not filter out `hostNetwork: true` pods.
When a `NetworkPolicy` with an empty or broad `podSelector` (`podSelector: {}`) is created in a namespace co-located with a `hostNetwork` pod (such as static `kube-apiserver` pods in `kube-system`), the node's host IP was enrolled into `podips-v4`. 
As a result, reply packets from host-network services (such as apiserver SYN-ACKs on same-node hairpin requests) matched `ip saddr @podips-v4 queue` in nftables and were routed to NFQUEUE userspace, where `EvaluateIngress` dropped the reply packets because the ephemeral client port did not match the pod's server ingress rules.


Fixes #380
Fixes #379
